### PR TITLE
Add sastocansat model

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = master
 [submodule "Tools/sitl_gazebo"]
 	path = Tools/sitl_gazebo
-	url = https://github.com/PX4/sitl_gazebo.git
+	url = https://github.com/sastosat/sitl_gazebo.git
 	branch = master
 [submodule "src/lib/matrix"]
 	path = src/lib/matrix

--- a/ROMFS/px4fmu_common/init.d-posix/1080_cansat
+++ b/ROMFS/px4fmu_common/init.d-posix/1080_cansat
@@ -1,0 +1,13 @@
+#!/bin/sh
+#
+# @name Cansat SITL
+#
+# @type Quadrotor Wide
+#
+# @maintainer Jaeyoung Lim <jaeyoung@auterion.com>
+#
+
+sh /etc/init.d/rc.mc_defaults
+
+set MIXER quad_w
+

--- a/platforms/posix/cmake/sitl_target.cmake
+++ b/platforms/posix/cmake/sitl_target.cmake
@@ -81,6 +81,7 @@ set(models none shell
 	plane plane_cam plane_catapult plane_lidar
 	standard_vtol tailsitter tiltrotor
 	rover r1_rover boat cloudship
+	cansat
 	uuv_hippocampus)
 set(worlds none empty baylands ksql_airport mcmillan_airfield sonoma_raceway warehouse windy)
 set(all_posix_vmd_make_targets)


### PR DESCRIPTION
**Describe problem solved by this pull request**
Cansats are a educational platform for students studying satellites. Simulating cansats will enable students to iterate faster on software for development

**Describe your solution**
This PR adds a Software-In-The-Loop simulation target for PX4 SITL
To try it, run
```
make px4_sitl gazebo_cansat
```

**Test data / coverage**
Demo video can be found here:
[![Demo](https://img.youtube.com/vi/ZVbQqPUZ1FY/0.jpg)](https://youtu.be/ZVbQqPUZ1FY)
Since PX4 is capable of logging the flight, the log can be visualized through flight review:
Log: https://review.px4.io/plot_app?log=35a0647d-f69f-4a19-bfe1-ea66d099a9a1

**Additional context**
